### PR TITLE
Update timeline.py to dynamically set resolution of the display

### DIFF
--- a/memento/timeline/timeline.py
+++ b/memento/timeline/timeline.py
@@ -12,8 +12,15 @@ import time
 
 class Timeline:
     def __init__(self):
-        self.window_size = utils.RESOLUTION
+        # Initialize the display module
+        pygame.display.init()
 
+        # Get display information
+        infoObject = pygame.display.Info()
+
+        # Set window_size to the current screen resolution
+        self.window_size = (infoObject.current_w, infoObject.current_h)
+        
         # Faster than pygame.init()
         pygame.display.init()
         pygame.font.init()


### PR DESCRIPTION
When i ran:
`memento-timeline`

I got a squished version of the screenshots, barely readable, making this change, it dynamically set to my monitor resolution and greatly improved my experience.