### PR TITLE
Mac compat

### DIFF
--- a/memento/utils.py
+++ b/memento/utils.py
@@ -6,6 +6,9 @@ import asyncio
 import cv2
 import numpy as np
 import os
+import platform
+
+op_platform = platform.system()
 
 FPS = 0.5
 SECONDS_PER_REC = 10
@@ -21,6 +24,8 @@ CACHE_PATH = os.path.join(os.environ["HOME"], ".cache", "memento")
 
 
 def get_active_window():
+    if op_platform == 'Darwin': # Doesn't work on mac and no simple python solution
+        return "None"
     display = Xlib.display.Display()
     window = display.get_input_focus().focus
     if isinstance(window, Xlib.xobject.drawable.Window):


### PR DESCRIPTION
Allows for basic Mac compatibility through:
1) Reorganizing the background object to prevent serializing complex objects into the `process_images` workers (by initializing the objects within the run function)
2) Commenting out `print("QUEUE SIZE", self.images_queue.qsize())` as multiprocessing queue.qsize() is not implemented for Mac
3) When on Mac `utils.get_active_window()` always returns None. I couldn't find a simple Mac python replacement. The best lead involved calling AppleScript through subprocess

Mac config:
Chip: Apple M3 Max
macOS: 14.1.1